### PR TITLE
Static Textures

### DIFF
--- a/src/core/BaseCharacter.h
+++ b/src/core/BaseCharacter.h
@@ -15,13 +15,7 @@ public:
     void bulletCollision(Bullet* bullet);
     Pool<Bullet>& getBulletPool() { return bulletPool; }
 
-    ~BaseCharacter()
-    {
-        if (bulletTexture.id != 0)
-        {
-            UnloadTexture(bulletTexture);
-        }
-    }
+    virtual ~BaseCharacter() = default;
 
 protected:
     Pool<Bullet> bulletPool;

--- a/src/core/GameObject.h
+++ b/src/core/GameObject.h
@@ -12,13 +12,7 @@ public:
 	bool getActive() { return isActive; }
 	void setActive(bool active) { isActive = active; }
 
-	virtual ~GameObject() 
-	{
-		if (texture.id != 0) 
-		{
-			UnloadTexture(texture);
-		}
-	}
+	virtual ~GameObject() = default;
 
 protected:
 	Texture2D texture{};            

--- a/src/entities/Enemy.cpp
+++ b/src/entities/Enemy.cpp
@@ -1,5 +1,8 @@
 #include "Enemy.h"
 
+Texture2D Enemy::sharedTexture = {};
+Texture2D Enemy::sharedBulletTexture = {};
+
 Enemy::Enemy()
 {
 	setActive(true);
@@ -7,8 +10,8 @@ Enemy::Enemy()
 	worldPos.y = 1280 / 4;
 	speed = 300.f;
 
-	texture = LoadTexture("assets/ships/Enemies/Enemies_T1.png");
-	bulletTexture = LoadTexture("assets/ships/Enemies/Enemies_T1_bullet.png");
+	texture = sharedTexture;
+	bulletTexture = sharedBulletTexture;
 	xRows = 4;
 	yRows = 1;
 	width = texture.width / xRows;
@@ -74,6 +77,18 @@ void Enemy::shoot()
 		Vector2 bulletPos{ worldPos.x + width / 2, worldPos.y + height / 2 };
 		bullet->initialize(bulletTexture, bulletPos, 600.f, 4, 1, 20);
 	}
+}
+
+void Enemy::LoadSharedTexture()
+{
+	sharedTexture = LoadTexture("assets/ships/Enemies/Enemies_T1.png");
+	sharedBulletTexture = LoadTexture("assets/ships/Enemies/Enemies_T1_bullet.png");
+}
+
+void Enemy::UnloadSharedTexture()
+{
+	UnloadTexture(sharedTexture);
+	UnloadTexture(sharedBulletTexture);
 }
 
 void Enemy::newPos()

--- a/src/entities/Enemy.h
+++ b/src/entities/Enemy.h
@@ -8,10 +8,12 @@ class Enemy : public BaseCharacter
 {
 public:
 	Enemy();
+	~Enemy() override = default;
 	void tick() override;
 	void undoMovement() override;
 	void shoot() override;
-	~Enemy() override = default;
+	static void LoadSharedTexture();
+	static void UnloadSharedTexture();
 
 private:
 	bool readyToShoot;
@@ -20,6 +22,8 @@ private:
 	Rectangle movBounds;
 	Vector2 direction;
 	float length;
+	static Texture2D sharedTexture;
+	static Texture2D sharedBulletTexture;
 
 	void newPos();
 };

--- a/src/entities/Player.h
+++ b/src/entities/Player.h
@@ -12,7 +12,11 @@ public:
     void takeDamage(int damage) override;
     bool isInvincible() const { return activeInvincibility > 0.0f; }
 
-    ~Player() override = default;
+    ~Player() override
+    {
+        if (texture.id != 0) UnloadTexture(texture);
+        if (bulletTexture.id != 0) UnloadTexture(bulletTexture);
+    }
 
 private:
     Vector2 lastFrameWorldPos{};

--- a/src/state/Level1State.cpp
+++ b/src/state/Level1State.cpp
@@ -3,7 +3,9 @@
 void Level1State::enterState()
 {
 	LevelData level = LevelLoader::loadLevel("json/lvl1.json");
-	for (int i = 0; i < 1 /*level.enemyCount*/; i++)
+
+	Enemy::LoadSharedTexture();
+	for (int i = 0; i < level.enemyCount; i++)
 	{
 		Enemy* enemy = new Enemy();
 		enemies.push_back(enemy);
@@ -20,6 +22,7 @@ void Level1State::exitState()
 	}
 
 	enemies.clear();
+	Enemy::UnloadSharedTexture();
 	UnloadTexture(map);
 }
 


### PR DESCRIPTION
Static Textures for enemies have been applied in order to avoid unnecessary texture loading