### PR TITLE
Add basic Pool tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.10)
+project(NebulaRaid)
+set(CMAKE_CXX_STANDARD 17)
+
+enable_testing()
+add_subdirectory(tests)

--- a/README.md
+++ b/README.md
@@ -44,3 +44,15 @@ This project is still in development. Planned improvements include:
 Stay tuned for updates as the project evolves!
 
 Disclaimer: None of the sounds, sprites or art used in the game are mine. All assets used in the project are open source or are used with the permission of the author.
+
+## Running Tests
+
+The unit tests are located in the `tests` directory and are built using CMake. To compile and run them:
+
+```bash
+cmake -S . -B build
+cmake --build build
+cd build && ctest
+```
+
+This will build the test executable and execute the tests.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.10)
+
+set(SOURCES
+    ../src/entities/Bullet.cpp
+    ../src/core/GameObject.cpp
+)
+
+add_executable(PoolTests PoolTests.cpp ${SOURCES})
+
+target_include_directories(PoolTests PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/tests)
+
+add_test(NAME PoolTests COMMAND PoolTests)

--- a/tests/PoolTests.cpp
+++ b/tests/PoolTests.cpp
@@ -1,0 +1,20 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+#include "raylib.h"
+#include "raymath.h"
+#include "../src/core/Pool.h"
+#include "../src/entities/Bullet.h"
+
+TEST_CASE(PoolBasic)
+{
+    Pool<Bullet> pool(2);
+    Bullet* b1 = pool.getObject();
+    CHECK(b1 != nullptr);
+    Bullet* b2 = pool.getObject();
+    CHECK(b2 != nullptr);
+    CHECK(pool.getObject() == nullptr);
+    pool.releaseObject(b1);
+    Bullet* b3 = pool.getObject();
+    CHECK(b3 == b1);
+    CHECK(pool.getObject() == nullptr);
+}

--- a/tests/doctest.h
+++ b/tests/doctest.h
@@ -1,0 +1,29 @@
+#ifndef DOCTEST_H
+#define DOCTEST_H
+#include <vector>
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+namespace doctest {
+    struct TestCase { const char* name; void(*func)(); };
+    inline std::vector<TestCase>& getTests(){ static std::vector<TestCase> t; return t; }
+    struct Reg{ Reg(const char* name, void(*func)()){ getTests().push_back({name, func}); } };
+}
+#define TEST_CASE(name) \
+    static void name(); \
+    static doctest::Reg reg_##name(#name, name); \
+    static void name()
+#define CHECK(expr) do{ if(!(expr)) throw std::runtime_error("Check failed: " #expr); }while(0)
+#ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+int main(){
+    int failures = 0;
+    for(auto& tc: doctest::getTests()){
+        try{ tc.func(); std::cout << tc.name << " - OK" << std::endl; }
+        catch(const std::exception& e){ failures++; std::cout << tc.name << " - FAILED: " << e.what() << std::endl; }
+        catch(...){ failures++; std::cout << tc.name << " - FAILED" << std::endl; }
+    }
+    if(failures) std::cout << failures << " test(s) failed" << std::endl;
+    return failures ? 1 : 0;
+}
+#endif
+#endif // DOCTEST_H

--- a/tests/raylib.h
+++ b/tests/raylib.h
@@ -1,0 +1,14 @@
+#ifndef RAYLIB_H
+#define RAYLIB_H
+#include <cmath>
+struct Texture2D { int id = 0; int width = 0; int height = 0; int mipmaps = 1; int format = 0; };
+struct Vector2 { float x = 0.0f; float y = 0.0f; };
+struct Rectangle { float x = 0.0f; float y = 0.0f; float width = 0.0f; float height = 0.0f; };
+struct Color { unsigned char r=0,g=0,b=0,a=0; };
+static const Color WHITE{255,255,255,255};
+static const Color RED{255,0,0,255};
+inline float GetFrameTime(){ return 0.016f; }
+inline bool CheckCollisionRecs(Rectangle, Rectangle){ return false; }
+inline void DrawRectangleLines(int,int,int,int,Color){}
+inline void DrawTexturePro(Texture2D, Rectangle, Rectangle, Vector2, float, Color){}
+#endif // RAYLIB_H

--- a/tests/raymath.h
+++ b/tests/raymath.h
@@ -1,0 +1,9 @@
+#ifndef RAYMATH_H
+#define RAYMATH_H
+#include <cmath>
+#include "raylib.h"
+inline Vector2 Vector2Add(Vector2 a, Vector2 b){ return {a.x+b.x, a.y+b.y}; }
+inline Vector2 Vector2Scale(Vector2 a, float s){ return {a.x*s, a.y*s}; }
+inline float Vector2Length(Vector2 v){ return std::sqrt(v.x*v.x + v.y*v.y); }
+inline Vector2 Vector2Normalize(Vector2 v){ float l=Vector2Length(v); return l==0?Vector2{0,0}:Vector2{v.x/l, v.y/l}; }
+#endif // RAYMATH_H


### PR DESCRIPTION
## Summary
- add doctest-based unit test for `Pool<Bullet>`
- provide minimal stubs for raylib and raymath
- set up CMake build for tests
- document how to build and run the new tests

## Testing
- `cmake .. && cmake --build . && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68401407b9d88326be87b0596bfad7e5