### PR TITLE
Fix Player double destruction in PlayState

### DIFF
--- a/src/state/PlayState.cpp
+++ b/src/state/PlayState.cpp
@@ -22,11 +22,13 @@ void PlayState::enterState()
 
 void PlayState::exitState()
 {
-	player.~Player();
-	for (auto enemy : enemies)
-	{
-		delete enemy;
-	}
+        // Player resources will be released when PlayState is destroyed.
+        // Avoid manually calling the destructor here to prevent double
+        // destruction when the state object is cleaned up.
+        for (auto enemy : enemies)
+        {
+                delete enemy;
+        }
 	enemies.clear();
 	EnemyFactory::unloadSharedTextures();
 	AudioManager::instance().stopMusic();


### PR DESCRIPTION
## Summary
- avoid manually calling the `Player` destructor when leaving `PlayState`

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6840127d1dac8326a3d7e03cb6472368