### PR TITLE
Fix menu start text

### DIFF
--- a/src/state/MenuState.cpp
+++ b/src/state/MenuState.cpp
@@ -21,7 +21,7 @@ void MenuState::update()
 	DrawText("Controls:", screenWidth / 2 - MeasureText("Controls:", 30) / 2, screenHeight / 4, 30, BLACK);
 	DrawText("WASD for movement", screenWidth / 2 - MeasureText("WASD for movement", 30) / 2, screenHeight / 4 + 40, 30, BLACK);
 	DrawText("Space for shooting", screenWidth / 2 - MeasureText("Space for shooting", 30) / 2, screenHeight / 4 + 80, 30, BLACK);
-	DrawText("Press intro to start: Level Mode", screenWidth / 2 - MeasureText("Press intro to start: Level Mode", 30) / 2, screenHeight / 2, 30, BLACK);
+        DrawText("Press enter to start: Level Mode", screenWidth / 2 - MeasureText("Press enter to start: Level Mode", 30) / 2, screenHeight / 2, 30, BLACK);
 	DrawText("Press space to start: Infinite Mode", screenWidth / 2 - MeasureText("Press space to start: Infinite Mode", 30) / 2, screenHeight / 2 + 40, 30, BLACK);
 
 	if (IsKeyPressed(KEY_ENTER))


### PR DESCRIPTION
## Summary
- update start prompt in MenuState from "intro" to "enter"

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684013bea3fc83269090538fb9856dbd