### PR TITLE
Fix GameObject bounds with GameConfig

### DIFF
--- a/src/core/GameObject.cpp
+++ b/src/core/GameObject.cpp
@@ -1,4 +1,5 @@
 #include "GameObject.h"
+#include "../utils/GameConfig.h"
 
 void GameObject::tick()
 {
@@ -32,8 +33,8 @@ bool GameObject::isOutOfBounds()
     return
         worldPos.x <= 0 ||
         worldPos.y <= 0 ||
-        worldPos.x + width * scale > 720 ||
-        worldPos.y + height * scale > 1280;
+        worldPos.x + width * scale > GameConfig::instance().screenWidth ||
+        worldPos.y + height * scale > GameConfig::instance().screenHeight;
 }
 
 Rectangle GameObject::getHitbox()


### PR DESCRIPTION
## Summary
- reference `GameConfig` screen dimensions in `GameObject::isOutOfBounds`
- include `GameConfig.h`

## Testing
- `g++ -std=c++17 -I./src -I./src/external -c src/core/GameObject.cpp` *(fails: raylib.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_684013dea5fc8326a6be044ad111fecf